### PR TITLE
Add basic architectury networking setup

### DIFF
--- a/template/{{ common_path }}/src/main/java/{{ package_path }}/casting/patterns/spells/OpCongrats.kt.jinja
+++ b/template/{{ common_path }}/src/main/java/{{ package_path }}/casting/patterns/spells/OpCongrats.kt.jinja
@@ -44,7 +44,7 @@ class OpCongrats : SpellAction {
     override fun execute(args: List<Iota>, ctx: CastingContext): Triple<RenderedSpell, Int, List<ParticleSpray>> {
         val target = args.getEntity(0, argc)
 
-        // makes sure that the position is inside the range
+        // makes sure that the target player is inside the range
         // the caster is allowed to affect.
         ctx.assertEntityInRange(target)
 
@@ -67,8 +67,8 @@ class OpCongrats : SpellAction {
      */
     private data class Spell(val player: {{ ServerPlayer }}) : RenderedSpell {
         override fun cast(ctx: CastingContext) {
-            ctx.caster.{{ _(mojmap="sendSystemMessage", yarn="sendMessage") }}({{ Component }}.translatable("text.{{ modid }}.congrats", player.displayName));
-            {{ classname }}Networking.sendToPlayer(ctx.caster, SetLookPitchS2CMsg(-90f))
+            player.{{ _(mojmap="sendSystemMessage", yarn="sendMessage") }}({{ Component }}.translatable("text.{{ modid }}.congrats", player.displayName));
+            {{ classname }}Networking.sendToPlayer(player, SetLookPitchS2CMsg(-90f))
         }
     }
 }

--- a/template/{{ common_path }}/src/main/java/{{ package_path }}/casting/patterns/spells/OpCongrats.kt.jinja
+++ b/template/{{ common_path }}/src/main/java/{{ package_path }}/casting/patterns/spells/OpCongrats.kt.jinja
@@ -18,6 +18,8 @@ import at.petrak.hexcasting.api.spell.mishaps.MishapBadEntity
     mojmap="net.minecraft.network.chat.Component",
     yarn="net.minecraft.text.Text",
 ) }}{% set Component = ns.import %}
+import {{ package }}.networking.{{ classname }}Networking
+import {{ package }}.networking.SetLookPitchS2CMsg
 
 class OpCongrats : SpellAction {
     /**
@@ -66,6 +68,7 @@ class OpCongrats : SpellAction {
     private data class Spell(val player: {{ ServerPlayer }}) : RenderedSpell {
         override fun cast(ctx: CastingContext) {
             ctx.caster.{{ _(mojmap="sendSystemMessage", yarn="sendMessage") }}({{ Component }}.translatable("text.{{ modid }}.congrats", player.displayName));
+            {{ classname }}Networking.sendToPlayer(ctx.caster, SetLookPitchS2CMsg(-90f))
         }
     }
 }

--- a/template/{{ common_path }}/src/main/java/{{ package_path }}/client/LookClient.java.jinja
+++ b/template/{{ common_path }}/src/main/java/{{ package_path }}/client/LookClient.java.jinja
@@ -1,0 +1,25 @@
+{% from "macros/mappings.jinja" import mappings as _, import, ns with context -%}
+
+package {{ package }}.client;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+{{ import(
+    mojmap="net.minecraft.client.Minecraft",
+    yarn="net.minecraft.client.MinecraftClient",
+) }}{% set MinecraftClient = ns.import %};
+
+/**
+ * This class is created to separate client-only code into a dedicated package.
+ */
+@Environment(EnvType.CLIENT)
+public class LookClient {
+    /**
+     * Alters the tilt of the player's head.
+     * @param pitch New pitch or {@code null}
+     */
+    public static void setLookPitch(float pitch) {
+        assert {{ MinecraftClient }}.getInstance().player != null;
+        {{ MinecraftClient }}.getInstance().player.{{ _(mojmap="setXRot", yarn="setPitch") }}(pitch);
+    }
+}

--- a/template/{{ common_path }}/src/main/java/{{ package_path }}/networking/SetLookPitchS2CMsg.java.jinja
+++ b/template/{{ common_path }}/src/main/java/{{ package_path }}/networking/SetLookPitchS2CMsg.java.jinja
@@ -1,0 +1,52 @@
+{% from "macros/mappings.jinja" import mappings as _, import, ns with context -%}
+
+package {{ package }}.networking;
+
+import dev.architectury.networking.NetworkManager;
+{{ import(
+    mojmap="net.minecraft.network.FriendlyByteBuf",
+    yarn="net.minecraft.network.PacketByteBuf",
+) }}{% set ByteBuf = ns.import %};
+import {{ package }}.client.LookClient;
+import java.util.function.Supplier;
+
+/**
+ * Class that implements the functionality necessary to create, send, and execute a command (in this case rotate view)
+ * from the server to a client in architectury.
+ */
+public class SetLookPitchS2CMsg {
+    private final float pitch;
+
+    /**
+     * Constructor for creation on the server.
+     * @param pitch Head pitch parameter.
+     */
+    public SetLookPitchS2CMsg(float pitch) {
+        this.pitch = pitch;
+    }
+
+    /**
+     * Constructor for recreation on the client from a {@link {{ ByteBuf }}} onto which it was encoded
+     * on the server using {@link #encode({{ ByteBuf }})}.
+     * @param buf Buffer onto which the message was encoded
+     */
+    public SetLookPitchS2CMsg({{ ByteBuf }} buf) {
+        this.pitch = buf.readFloat();
+    }
+
+    /**
+     * Method that encodes the message, preparing it for transmission over the network.
+     * @param buf Buffer onto which the message will be encoded
+     */
+    public void encode({{ ByteBuf }} buf) {
+        buf.writeFloat(pitch);
+    }
+
+    /**
+     * Executes the command.
+     * @param contextSupplier Supplier of the context that is used to schedule the timely execution of the message.
+     */
+    public void apply(Supplier<NetworkManager.PacketContext> contextSupplier) {
+        contextSupplier.get().queue(() -> LookClient.setLookPitch(pitch));
+    }
+}

--- a/template/{{ common_path }}/src/main/java/{{ package_path }}/networking/{{ classname }}Networking.java.jinja
+++ b/template/{{ common_path }}/src/main/java/{{ package_path }}/networking/{{ classname }}Networking.java.jinja
@@ -1,0 +1,31 @@
+{% from "macros/mappings.jinja" import mappings as _, import, ns with context -%}
+
+package {{ package }}.networking;
+
+import dev.architectury.networking.NetworkChannel;
+{{ import(
+    mojmap="net.minecraft.server.level.ServerPlayer",
+    yarn="net.minecraft.server.network.ServerPlayerEntity",
+) }}{% set ServerPlayer = ns.import %};
+
+import static {{ package }}.{{ classname }}.id;
+
+public class {{ classname }}Networking {
+    private static final NetworkChannel CHANNEL = NetworkChannel.create(id("networking_channel"));
+
+    public static void init() {
+        CHANNEL.register(SetLookPitchS2CMsg.class, SetLookPitchS2CMsg::encode, SetLookPitchS2CMsg::new, SetLookPitchS2CMsg::apply);
+    }
+
+    public static <T> void sendToServer(T message) {
+        CHANNEL.sendToServer(message);
+    }
+
+    public static <T> void sendToPlayer({{ ServerPlayer }} player, T message) {
+        CHANNEL.sendToPlayer(player, message);
+    }
+
+    public static <T> void sendToPlayers(Iterable<{{ ServerPlayer }}> players, T message) {
+        CHANNEL.sendToPlayers(players, message);
+    }
+}

--- a/template/{{ common_path }}/src/main/java/{{ package_path }}/{{ classname }}.java.jinja
+++ b/template/{{ common_path }}/src/main/java/{{ package_path }}/{{ classname }}.java.jinja
@@ -5,6 +5,7 @@ package {{ package }};
 import {{ package }}.registry.{{ classname }}IotaTypeRegistry;
 import {{ package }}.registry.{{ classname }}ItemRegistry;
 import {{ package }}.registry.{{ classname }}PatternRegistry;
+import {{ package }}.networking.{{ classname }}Networking;
 {{ import(
     mojmap="net.minecraft.resources.ResourceLocation",
     yarn="net.minecraft.util.Identifier",
@@ -28,6 +29,7 @@ public class {{ classname }} {
         {{ classname }}ItemRegistry.init();
         {{ classname }}IotaTypeRegistry.init();
         {{ classname }}PatternRegistry.init();
+		{{ classname }}Networking.init();
 
         LOGGER.info({{ classname }}Abstractions.getConfigDirectory().toAbsolutePath().normalize().toString());
     }

--- a/template/{{ common_path }}/src/main/resources/assets/{{ modid }}/lang/en_us.json.jinja
+++ b/template/{{ common_path }}/src/main/resources/assets/{{ modid }}/lang/en_us.json.jinja
@@ -6,7 +6,7 @@
   "hexcasting.spell.book.{{ modid }}:signum": "Dum. Actn.",
   "{{ modid }}.entry.dummy_spells": "Dummy Spells",
   "{{ modid }}.entry.dummy_actions": "Dummy Actions",
-  "{{ modid }}.page.dummy_spells.congrats": "Accepts a player entity, tells them they are doing a good job.",
+  "{{ modid }}.page.dummy_spells.congrats": "Accepts a player entity, tells them they are doing a good job and makes them look up.",
   "{{ modid }}.page.dummy_actions.signum": "Accepts a $(l:casting/101)number/$, returns -1 if it is negative, 0 if 0, 1 if positive.",
   "text.{{ modid }}.congrats": "Good job, %1$s!",
   "text.{{ modid }}.congrats.player": "a Player"


### PR DESCRIPTION
Architectury allows to implement platform-abstract networking in a simple and elegant way, and the added example is intended to demonstrate this to addon developers that might be less familiar with the it, as well as provide an easily adaptable baseline setup.